### PR TITLE
feat(passkit): Work towards localizable pass files

### DIFF
--- a/passkit/lib/src/strings_parser/naive_strings_file_parser.dart
+++ b/passkit/lib/src/strings_parser/naive_strings_file_parser.dart
@@ -1,0 +1,27 @@
+/// Here's a breakdown of the pattern:
+/// - r'"((?:\"|[^"])*)"': This section matches the key, which is enclosed in
+///   double quotes. Inside the quotes, it captures any character sequence that
+///   is either a backslash-escaped double quote or any character that is not a
+///   double quote.
+/// - \s?=\s?: This part matches the equals sign with optional whitespace before
+///   and after it.
+/// - r'"((?:\"|[^"])*)"': This section matches the value, using a similar
+///   pattern to capture any character sequence within double quotes.
+/// - \s?;: This last part matches optional whitespace followed by a semicolon.
+final _stringsParserRegEx =
+    RegExp(r'"((?:\\"|[^"])*)"\s?=\s?"((?:\\"|[^"])*)"\s?;');
+
+/// This method uses a quite naive approach to parse Apples `strings` file
+/// format with a [RegExp]. It doesn't support placeholders.
+///
+/// See also:
+/// - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html
+/// - https://localizely.com/apple-strings-file/
+Map<String, String> naiveStringsFileParser(String stringsFile) {
+  final matches = _stringsParserRegEx
+      .allMatches(stringsFile)
+      .where((match) => match.group(1) != null && match.group(2) != null)
+      .map((match) => MapEntry(match.group(1)!, match.group(2)!));
+
+  return Map.fromEntries(matches);
+}

--- a/passkit/lib/src/strings_parser/naive_strings_file_parser.dart
+++ b/passkit/lib/src/strings_parser/naive_strings_file_parser.dart
@@ -1,3 +1,15 @@
+import 'dart:convert';
+
+/// Parses [content] to a [Map<String, String>] which contains the
+/// key-value-pairs for translations.
+Map<String, String> parseStringsFile(List<int> content) {
+  final string = _stringsFileDecoder.convert(content);
+  return naiveStringsFileParser(string);
+}
+
+// TODO(ueman): `.strings` files should be read as UTF-16, not UTF-8.
+final Converter<List<int>, String> _stringsFileDecoder = const Utf8Decoder();
+
 /// Here's a breakdown of the pattern:
 /// - r'"((?:\"|[^"])*)"': This section matches the key, which is enclosed in
 ///   double quotes. Inside the quotes, it captures any character sequence that
@@ -13,6 +25,8 @@ final _stringsParserRegEx =
 
 /// This method uses a quite naive approach to parse Apples `strings` file
 /// format with a [RegExp]. It doesn't support placeholders.
+///
+/// The returned map has key value pairs.
 ///
 /// See also:
 /// - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html

--- a/passkit/test/strings_file_parser_test.dart
+++ b/passkit/test/strings_file_parser_test.dart
@@ -1,0 +1,34 @@
+import 'package:passkit/src/strings_parser/naive_strings_file_parser.dart';
+import 'package:test/test.dart';
+
+// Taken from https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/PassKit_PG/Creating.html
+final _testString = '''"origin_SVQ" = "Sevilla";
+"destination_LHR" = "Londres";
+''';
+
+// Taken from https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html
+final _testStringWithComments = '''/* Insert Element menu item */
+"Insert Element" = "Insert Element";
+/* Error string used for unknown error types. */
+"ErrorString_1" = "An unknown error occurred.";
+''';
+
+void main() {
+  test('naiveStringsFileParser() parses example correctly', () {
+    final keyValue = naiveStringsFileParser(_testString);
+    expect(keyValue, {
+      'origin_SVQ': 'Sevilla',
+      'destination_LHR': 'Londres',
+    });
+  });
+
+  test(
+      'naiveStringsFileParser() parsess example correctly despite comments in it',
+      () {
+    final keyValue = naiveStringsFileParser(_testStringWithComments);
+    expect(keyValue, {
+      'Insert Element': 'Insert Element',
+      'ErrorString_1': 'An unknown error occurred.',
+    });
+  });
+}


### PR DESCRIPTION
This works towards localizable passes. In particular, it adds naive parsing of the strings files.

- no external API to read the various entries in a localized way
- no localized images
- it still uses UTF-8 instead of UTF-16
- parsing is done via regex, which might fail

Related to https://github.com/ueman/passkit/issues/8