### PR TITLE
fix(passkit): Clamp image resolutions to 1, 2, and 3

### DIFF
--- a/passkit/lib/src/passkit/pk_pass_image.dart
+++ b/passkit/lib/src/passkit/pk_pass_image.dart
@@ -19,7 +19,7 @@ class PkPassImage {
   }
 
   Uint8List fromMultiplier(int multiplier) {
-    assert(multiplier == 1 || multiplier == 2 || multiplier == 3);
+    multiplier = multiplier.clamp(1, 3);
     return switch (multiplier) {
       1 => (image1 ?? image2 ?? image3)!,
       2 => (image2 ?? image3 ?? image1)!,


### PR DESCRIPTION
According to the spec, there's no other resolutions than 1, 2 and 3x, so we might as well clamp it to that range.

Previously, it was possible to request out of bounds resolutions. This is no longer the case.