### PR TITLE
notify Flutter on PKAddPassesViewController viewDidDisappear in addPassFlow and addPassesFlow

### DIFF
--- a/apple_passkit/ios/apple_passkit/Sources/apple_passkit/ApplePasskitPlugin.swift
+++ b/apple_passkit/ios/apple_passkit/Sources/apple_passkit/ApplePasskitPlugin.swift
@@ -72,9 +72,12 @@ public class ApplePasskitPlugin: NSObject, FlutterPlugin {
             result(ErrorCodes.empty)
             return
         }
-        let vc = PKAddPassesViewController(pass: pkPass)!
+        let vc = CustomPKAddPassesViewController(pass: pkPass)!
+        vc.onViewDidDisappearCompletion = {
+            result(nil)
+        }
+        
         present(vc)
-        result(nil)
     }
     
     private func addPassesFlow(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -83,9 +86,12 @@ public class ApplePasskitPlugin: NSObject, FlutterPlugin {
             result(ErrorCodes.empty)
             return
         }
-        let vc = PKAddPassesViewController(passes: pkPasses)!
+        let vc = CustomPKAddPassesViewController(passes: pkPasses)!
+        vc.onViewDidDisappearCompletion = {
+            result(nil)
+        }
+        
         present(vc)
-        result(nil)
     }
     
     private func addPassesWithoutFlow(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -146,4 +152,14 @@ public class ApplePasskitPlugin: NSObject, FlutterPlugin {
 
 enum ErrorCodes {
     static let empty = FlutterError(code: "empty", message: "Received data for PKPass was empty", details: nil)
+}
+
+
+class CustomPKAddPassesViewController : PKAddPassesViewController {
+    var onViewDidDisappearCompletion: (() -> Void)?
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        onViewDidDisappearCompletion?()
+    }
 }


### PR DESCRIPTION
This PR makes it possible to execute Dart code (e.g. refresh UI) when the native UIViewController has been dismissed, i.e. after the pass has been added.

Closes #107 