### PR TITLE
fixing to add multiple passes for ios

### DIFF
--- a/apple_passkit/ios/apple_passkit/Sources/apple_passkit/ApplePasskitPlugin.swift
+++ b/apple_passkit/ios/apple_passkit/Sources/apple_passkit/ApplePasskitPlugin.swift
@@ -18,7 +18,7 @@ public class ApplePasskitPlugin: NSObject, FlutterPlugin {
       case "addPasses":
           addPassesWithoutFlow(call, result)
       case "addPassesViewController":
-          addPassFlow(call, result)
+          addPassesFlow(call, result)
       case "addPassViewController":
           addPassFlow(call, result)
       case "getPasses":


### PR DESCRIPTION
**_Issue_**: Multiple-pass flow isn’t invoked because both cases call addPassFlow.

Current switch in **_ApplePasskitPlugin.swift_**
```
public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
    switch call.method {
    case "isPassLibraryAvailable":
        isPassLibaryAvailable(result)
    case "canAddPasses":
        canAddPasses(result)
    case "addPasses":
        addPassesWithoutFlow(call, result)
    case "addPassesViewController":
        addPassFlow(call, result)
    case "addPassViewController":
        addPassFlow(call, result)
    case "getPasses":
        getPasses(result)
    case "containsPass":
        containsPass(call, result)
    default:
        result(FlutterMethodNotImplemented)
    }
}
```

**_Expected behavior / Fix_**

"**addPassesViewController**" should call **addPassesFlow**.

 ```
case "addPassesViewController":
-    addPassFlow(call, result)
+    addPassesFlow(call, result)
 case "addPassViewController":
     addPassFlow(call, result)

Corrected switch (for clarity)
public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
    switch call.method {
    case "isPassLibraryAvailable":
        isPassLibaryAvailable(result)
    case "canAddPasses":
        canAddPasses(result)
    case "addPasses":
        addPassesWithoutFlow(call, result)
    case "addPassesViewController":
        addPassesFlow(call, result)
    case "addPassViewController":
        addPassFlow(call, result)
    case "getPasses":
        getPasses(result)
    case "containsPass":
        containsPass(call, result)
    default:
        result(FlutterMethodNotImplemented)
    }
}
```


**_Note: addPassesWithoutFlow already works as expected._**